### PR TITLE
Potential fix for code scanning alert no. 4: Binding a socket to all network interfaces

### DIFF
--- a/infra/railcar.py
+++ b/infra/railcar.py
@@ -8,7 +8,7 @@ import socket
 
 def find_open_port() -> int:
     s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-    s.bind(("", 0))
+    s.bind(('127.0.0.1', 0))
     port = s.getsockname()[1]
     s.close()
     return port


### PR DESCRIPTION
Potential fix for [https://github.com/mayant15/railcar/security/code-scanning/4](https://github.com/mayant15/railcar/security/code-scanning/4)

To address this issue, we should modify the socket bind operation in the `find_open_port()` function so that it binds only to the loopback interface (`'127.0.0.1'`) instead of to all interfaces (`''`). This minimizes the exposure and follows recommended best practices. Specifically, in `infra/railcar.py`, line 11 should be replaced with `s.bind(('127.0.0.1', 0))`. No other code or import changes are needed since the rest of the logic (port selection and reporting) remains unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
