### PR TITLE
fix(cli): shmem len for coverage map

### DIFF
--- a/packages/cli/src/feedback.rs
+++ b/packages/cli/src/feedback.rs
@@ -27,8 +27,8 @@ type CoverageObserver = HitcountsMapObserver<StdMapObserver<'static, u8, false>>
 type CoverageFeedback = AflMapFeedback<CoverageObserver, CoverageObserver>;
 
 #[inline]
-unsafe fn get_coverage_mut_ptr<S: ShMem>(shmem: &mut S) -> *mut u8 {
-    shmem.as_mut_ptr().add(4)
+unsafe fn get_coverage_slice<S: ShMem>(shmem: &mut S) -> &mut [u8] {
+    &mut shmem[4..]
 }
 
 #[inline]
@@ -52,9 +52,8 @@ where
     S: ShMem,
 {
     HitcountsMapObserver::new(unsafe {
-        let len = shmem.len();
-        let ptr = get_coverage_mut_ptr(shmem);
-        StdMapObserver::from_mut_ptr("CodeCoverage", ptr, len)
+        let map = get_coverage_slice(shmem);
+        StdMapObserver::from_mut_ptr("CodeCoverage", map.as_mut_ptr(), map.len())
     })
 }
 


### PR DESCRIPTION
Length passed to coverage map observer was four more than it should have been. So `reset_map()` in `StdMapObserver` would try to access what it thought was the last four bytes, but that would go past the mmap-ed shmem. This apparently [raises a SIGBUS](https://www.man7.org/linux/man-pages/man2/mmap.2.html).

I don't know what the exact cause of the difference is, but on my Debian (kernel 6.12) it worked "fine" but on our lab Ubuntu (kernel 6.8) it hangs.

Passing the correct length now as God intended.